### PR TITLE
docs: switch chatbot pattern file to sketch cloud

### DIFF
--- a/src/content/experimental/chatbot/overview.mdx
+++ b/src/content/experimental/chatbot/overview.mdx
@@ -90,7 +90,7 @@ While conversational interfaces may contain many different kinds of components, 
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>
   <ClickableTile
     title="Chatbot Sketch library"
-    href="https://ibm.box.com/s/blx6a2z2qnp5dtmi7xz0zfj22dkac1k2"
+    href="sketch://add-library/cloud/k8j5g"
     type="resource">
 
 ![](/images/sketch-icon.png)


### PR DESCRIPTION
This PR changes the link in the chatbot pattern documentation to use Sketch Cloud